### PR TITLE
Fix gzip bug

### DIFF
--- a/io.mbt
+++ b/io.mbt
@@ -788,7 +788,7 @@ pub fn read_all(r : &Reader) -> (Slice[Byte], IOError?) {
   let mut arr = Array::make(cap, b'\x00')
   let mut b = Slice::new(arr, end=0)
   for {
-    let (n, err) = r.read(b[b.length():cap])
+    let (n, err) = r.read(b[b.length():b.cap()])
     let mut err = err
     b = b[:b.length() + n]
     if err != None {
@@ -805,10 +805,10 @@ pub fn read_all(r : &Reader) -> (Slice[Byte], IOError?) {
         // thereafter, just add another 1<<20
         cap += mb
       }
-      let new_arr = Array::new(capacity=cap)
+      let new_arr = Array::make(cap, b'\x00')
       // Array::unsafe_blit(new_arr, 0, arr, 0, b.length())  // Doesn't work on wasm, wasm-gc, native
       for i in 0..<b.length() {
-        new_arr.push(arr[i])
+        new_arr[i] = arr[i]
       }
       arr = new_arr
       b = Slice::new(arr)[:b.length()]

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,6 +1,6 @@
 {
   "name": "gmlewis/io",
-  "version": "0.22.19",
+  "version": "0.23.0",
   "deps": {
     "gmlewis/base64": "0.15.5"
   },

--- a/repro_test.mbt
+++ b/repro_test.mbt
@@ -1,0 +1,32 @@
+///|
+struct MultiReader {
+  mut count : Int
+}
+
+///|
+impl @io.Reader for MultiReader with read(self, buf) {
+  if self.count >= 2 {
+    return (0, Some(@io.eof))
+  }
+  // Return exactly the buffer length to trigger resize in read_all if possible
+  let n = buf.length()
+  for i in 0..<n {
+    buf[i] = b'a'
+  }
+  self.count += 1
+  (n, None)
+}
+
+///|
+test "read_all resize bug" {
+  let r : MultiReader = MultiReader::{ count: 0 }
+  // read_all initial cap is 512.
+  // First read will fill 512 bytes.
+  // Then it will resize to 1024.
+  // Second read will try to read into b[512:1024].
+  let (res, err) = @io.read_all(r)
+  if err != None {
+    abort("Should not have error")
+  }
+  inspect(res.length(), content="1024")
+}

--- a/slice.mbt
+++ b/slice.mbt
@@ -95,7 +95,7 @@ pub fn[T] Slice::op_as_view(
     None => self.len
     Some(end) => end
   }
-  guard self.start + start >= 0 && start <= end && end <= len else {
+  guard self.start + start >= 0 && start <= end && self.start + end <= len else {
     abort("View start index out of bounds")
   }
   Slice::{ buf: self.buf, start: self.start + start, len: end - start }


### PR DESCRIPTION
# Dependency Fixes Required

A bug was discovered in the `gmlewis/io` and `gmlewis/flate` packages that causes a "View start index out of bounds" abort when performing Gzip decompression using `read_all`.

## 1. gmlewis/io

### File: `io.mbt`

The `read_all` function has a bug in how it reslices the buffer:

**Current Code:**
```moonbit
pub fn read_all(r : &Reader) -> (Slice[Byte], IOError?) {
  let mb = 1 << 20
  let mut cap = 512
  let mut arr = Array::make(cap, b'\x00')
  let mut b = Slice::new(arr, end=0)
  for {
    let (n, err) = r.read(b[b.length():cap]) // <--- BUG HERE
    let mut err = err
    b = b[:b.length() + n]
    // ...
```

**Issue:**
`b[b.length():cap]` uses `cap` as the `end` index relative to the slice `b`. However, `cap` is the *total capacity* of the underlying array. If `b` has a non-zero `start` offset (though in this specific case it starts at 0), `cap` might exceed the allowed bounds of the slice reslicing. Even if `b.start` is 0, the `Slice::op_as_view` implementation has a confusing guard.

**Recommended Fix:**
Use the `cap()` method of the slice to get the remaining capacity.
```moonbit
    let (n, err) = r.read(b[b.length():b.cap()])
```

### File: `slice.mbt`

The `op_as_view` implementation allows reslicing beyond the current slice's length but has a confusing guard:

**Current Code:**
```moonbit
pub fn[T] Slice::op_as_view(
  self : Slice[T],
  start? : Int = 0,
  end? : Int,
) -> Slice[T] {
  let len = self.buf.length()
  let end = match end {
    None => self.len
    Some(end) => end
  }
  guard self.start + start >= 0 && start <= end && end <= len else {
    abort("View start index out of bounds")
  }
  Slice::{ buf: self.buf, start: self.start + start, len: end - start }
}
```

**Issue:**
The guard `end <= len` (where `len` is `self.buf.length()`) allows reslicing up to the capacity of the underlying buffer. However, `self.start + end` should be checked against `self.buf.length()`, not just `end`.

## 2. gmlewis/flate

### File: `inflate.mbt`

The `Decompressor::read` implementation also performs slicing:

**Current Code:**
```moonbit
      for i = 0; i < n; i = i + 1 {
        b[i] = self.to_read[i]
      }
      self.to_read = self.to_read[n:]
```

**Issue:**
If `n` is equal to `self.to_read.length()`, `self.to_read[n:]` is called. In `Slice::op_as_view`, if `end` is `None`, it defaults to `self.len`. So it calls `op_as_view(start=n, end=n)`.
The guard `start <= end && end <= len` is checked.
If `self.to_read` was already a sub-slice of a larger buffer, its `len` (capacity) is `self.buf.length()`.
The check `end <= len` passes.

However, many MoonBit users expect slicing to be relative to the *slice length*, not the underlying buffer capacity.

## Reproducer

The following test case in `gmlewis/fonts` demonstrates the issue when loading a Gzip-compressed font:

```moonbit
async test "load_font success" {
  let font = @fonts.Font::load_font("baloo")
  inspect(font.id, content="baloo")
}
```

It fails with `View start index out of bounds` at `slice.mbt:99:5-99:44@gmlewis/io`.
